### PR TITLE
fix: misc formatting and link fixes

### DIFF
--- a/ERCS/erc-7726.md
+++ b/ERCS/erc-7726.md
@@ -1,13 +1,14 @@
 ---
-eip: 7777
+eip: 7726 
 title: Common Quote Oracle
-description: Standard API for data feeds providing the relative value of assets in the Ethereum and EVM-compatible blockchains.
+description: Interface for data feeds providing the relative value of assets in the Ethereum and EVM-compatible blockchains.
 author: alcueca (@alcueca), ruvaag (@ruvaag), totomanov (@totomanov), r0ohafza (@r0ohafza)
-discussions-to: https://ethereum-magicians.org/t/erc-for-oracle-value-feeds/20351
+discussions-to: https://ethereum-magicians.org/t/erc-7726-common-quote-oracle/20351
 status: Draft
 type: Standards Track
 category: ERC
 created: 2024-06-20
+requires: 7528
 ---
 
 ## Abstract
@@ -70,7 +71,7 @@ MUST revert with `OracleUntrustedData` if not capable to provide data within a d
 
 Some assets under the scope of this specification don't have an address, such as ETH, BTC and national currencies.
 
-For ETH, ERC-7535 will be applied, using `0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE` as its address.
+For ETH, [ERC-7528](./erc-7528.md) will be applied, using `0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE` as its address.
 
 For BTC, the address will be `0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB`.
 
@@ -117,7 +118,7 @@ The use of `getQuote` doesn't require the consumer to be aware of any decimal pa
 for the `base` or `quote` and should be preferred in most data processing cases.
 
 The spec doesn't include a `getPrice` function because it is rarely needed on-chain, and it would be a decimal number of
-difficult representation. The popular option for representing prices can be implemented for ERC20 with decimals as
+difficult representation. The popular option for representing prices can be implemented for [ERC-20](./eip-20.md) with decimals as
 `oracle.quoteOf(base, quote, 10\*\*base.decimals()) and will give the value of a whole unit of base in quote terms.
 
 ## Backwards Compatibility
@@ -134,4 +135,4 @@ Consumers should review these guarantees and use them to decide whether to integ
 
 ## Copyright
 
-Copyright and related rights waived via [CC0](https://eips.ethereum.org/LICENSE).
+Copyright and related rights waived via [CC0](../LICENSE.md).


### PR DESCRIPTION
TBD
- remove external links to alcueca's article and euler's whitepaper since [proposals cannot contain external links](https://ethereum.github.io/eipw/markdown-rel-links/). we could cite the articles only by name and quote relevant sections in text to satisfy this?
- address [overflow comment](https://github.com/ethereum/ERCs/pull/500/files#r1648222857)